### PR TITLE
BRS-4401 Manually close reconcile context

### DIFF
--- a/controllers/pgdatabase_controller.go
+++ b/controllers/pgdatabase_controller.go
@@ -53,6 +53,8 @@ type PgDatabaseReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *PgDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	logger := log.FromContext(ctx)
 
 	var database apiV1.PgDatabase

--- a/controllers/pginstance_controller.go
+++ b/controllers/pginstance_controller.go
@@ -53,6 +53,8 @@ type PgInstanceReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *PgInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	logger := log.FromContext(ctx)
 
 	var instance apiV1.PgInstance

--- a/controllers/pguser_controller.go
+++ b/controllers/pguser_controller.go
@@ -62,6 +62,8 @@ type PgUserReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *PgUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	logger := log.FromContext(ctx)
 
 	var user apiV1.PgUser

--- a/controllers/pguser_controller.go
+++ b/controllers/pguser_controller.go
@@ -69,12 +69,12 @@ func (r *PgUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	var user apiV1.PgUser
 	exists, err := getResource(ctx, r, req.NamespacedName, &user)
 	if err != nil {
-		logger.Error(err, "Unable to fetch PgDatabase", "database", req.NamespacedName.String())
+		logger.Error(err, "Unable to fetch PgUser", "user", req.NamespacedName.String())
 		return ctrl.Result{}, err
 	}
 	// Handle deleted
 	if !exists {
-		logger.Info("Deleted PgDatabase", "database", req.NamespacedName.String())
+		logger.Info("Deleted PgUser", "user", req.NamespacedName.String())
 		return ctrl.Result{}, nil
 	}
 
@@ -87,7 +87,7 @@ func (r *PgUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Handle finalizing
 	if user.DeletionTimestamp != nil {
 		if err := r.finalize(ctx, &user, pgApi); err != nil {
-			logger.Info("Unable to finalize", "database", req.NamespacedName.String(), "instance", user.GetInstanceIdString())
+			logger.Info("Unable to finalize", "user", req.NamespacedName.String(), "instance", user.GetInstanceIdString())
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}
 		// Exit and do not reconcile anymore
@@ -129,7 +129,7 @@ func (r *PgUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
-	logger.Info("Processed user", "database", user.ToNamespacedName(), "instance", user.GetInstanceIdString())
+	logger.Info("Processed user", "user", user.ToNamespacedName(), "instance", user.GetInstanceIdString())
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
The reconcile contexts are not done automatically, therefore we need to close the context, when the reconcile gets finished