### PR TITLE
BRS-4215 Add additional conditions for PgUser and PgDatabase

### DIFF
--- a/api/v1/pgdatabase_types.go
+++ b/api/v1/pgdatabase_types.go
@@ -24,6 +24,7 @@ import (
 // DefaultFinalizerPgDatabase contains the name for the default finalizer
 // of the PgDatabase resource
 const DefaultFinalizerPgDatabase = "postgres.brose.bike/pgdatabase"
+const PgDatabaseExistsConditionType string = "pgdatabase.postgres.brose.bike/exists"
 
 type PgDatabaseDeletion struct {
 	// Drop specifies if the database should be dropped on deletion (defaults to false)

--- a/api/v1/pguser_types.go
+++ b/api/v1/pguser_types.go
@@ -24,7 +24,8 @@ import (
 )
 
 const DefaultFinalizerPgUser = "postgres.brose.bike/pgloginrole"
-const PgUserExistsConditionType string = "postgres.brose.bike/login-role-exists"
+const PgUserExistsConditionType string = "pguser.postgres.brose.bike/exists"
+const PgUserDatabasesExistsConditionType string = "pguser.postgres.brose.bike/databases"
 
 // +kubebuilder:validation:Enum=CONNECT;CREATE
 type DatabasePrivilege string

--- a/controllers/pgdatabase_controller.go
+++ b/controllers/pgdatabase_controller.go
@@ -91,7 +91,12 @@ func (r *PgDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
-	// Install Extensions if missing
+	// Update Database Exists Condition
+	if err := setCondition(ctx, r.Status(), &database, apiV1.PgDatabaseExistsConditionType, true, "DatabaseExists", "-"); err != nil {
+		return ctrl.Result{RequeueAfter: time.Minute}, err
+	}
+
+	// Update Default Privileges
 	if err := r.handleDefaultPrivileges(ctx, pgApi, &database); err != nil {
 		logger.Error(err, "Unable to update default privileges", "database", database.Name, "instance", database.GetInstanceIdString())
 		return ctrl.Result{RequeueAfter: time.Minute}, err
@@ -115,7 +120,7 @@ func (r *PgDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		err = r.Update(ctx, &database)
 		if err != nil {
 			logger.Error(err, "Failed to update finalizers", "database", database.ToNamespacedName(), "instance", database.GetInstanceIdString())
-			return ctrl.Result{RequeueAfter: time.Minute}, err
+			return ctrl.Result{RequeueAfter: time.Second}, err
 		}
 	}
 
@@ -182,6 +187,10 @@ func (r *PgDatabaseReconciler) finalize(ctx context.Context, database *apiV1.PgD
 				logger.Error(err, "Unable to remove database", "database", database.Name, "instance", database.GetInstanceIdString())
 				return err
 			}
+		}
+		// Update Database Exists Condition
+		if err := setCondition(ctx, r.Status(), database, apiV1.PgDatabaseExistsConditionType, false, "DatabaseMissing", "Database was deleted"); err != nil {
+			return err
 		}
 	}
 	if database.Spec.DeletionBehavior.Wait {

--- a/controllers/pgdatabase_controller_test.go
+++ b/controllers/pgdatabase_controller_test.go
@@ -285,7 +285,7 @@ var _ = Describe("PgInstanceReconciler", func() {
 		var database apiV1.PgDatabase
 		err = k8sClient.Get(ctx, request.NamespacedName, &database)
 		Expect(err).To(BeNil())
-		Expect(database.Status.Conditions).To(HaveLen(1))
+		Expect(database.Status.Conditions).To(HaveLen(2))
 		Expect(database.Status.Conditions[0].Status).To(Equal(metaV1.ConditionTrue))
 
 		// and

--- a/controllers/pginstance_controller.go
+++ b/controllers/pginstance_controller.go
@@ -79,7 +79,7 @@ func (r *PgInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err := pgApi.TestConnection(); err != nil {
 		logger.Error(err, "Unable to connect", "instance", instance.Namespace+"/"+instance.Name)
 		// Update connection status
-		if err := setCondition(ctx, r, &instance, apiV1.PgConnectedConditionType, false, apiV1.PgConnectedConditionReasonConFailed, err.Error()); err != nil {
+		if err := setCondition(ctx, r.Status(), &instance, apiV1.PgConnectedConditionType, false, apiV1.PgConnectedConditionReasonConFailed, err.Error()); err != nil {
 			logger.Error(err, "Unable to update condition", "instance", req.NamespacedName.String())
 			return ctrl.Result{RequeueAfter: time.Minute}, err
 		}

--- a/controllers/pguser_controller.go
+++ b/controllers/pguser_controller.go
@@ -337,7 +337,6 @@ func (r *PgUserReconciler) checkIfDatabasesExist(ctx context.Context, pgApi PgRo
 		}
 		databaseNames[item.Name] = exists
 	}
-	allDatabasesExist := true
 	reason := "DatabasesExist"
 	message := "All databases exist"
 	missingDBs := make([]string, 0)
@@ -346,8 +345,9 @@ func (r *PgUserReconciler) checkIfDatabasesExist(ctx context.Context, pgApi PgRo
 			continue
 		}
 		missingDBs = append(missingDBs, name)
-		allDatabasesExist = allDatabasesExist && exist
 	}
+	// evaluate collected informations
+	allDatabasesExist := len(missingDBs) == 0
 	if len(missingDBs) > 0 {
 		reason = "DatabasesMissing"
 		message = "The instance does not contain the databases: " + strings.Join(missingDBs, ",")

--- a/controllers/pguser_controller.go
+++ b/controllers/pguser_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 
 	coreV1 "k8s.io/api/core/v1"
@@ -99,7 +100,7 @@ func (r *PgUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 	// Update Login Role Exists Condition
-	if err := setCondition(ctx, r, &user, apiV1.PgUserExistsConditionType, true, "-", "-"); err != nil {
+	if err := setCondition(ctx, r.Status(), &user, apiV1.PgUserExistsConditionType, true, "UserExists", "-"); err != nil {
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
@@ -115,6 +116,15 @@ func (r *PgUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{RequeueAfter: time.Minute}, err
 	}
 
+	// Check if databases exist
+	existing, err := r.checkIfDatabasesExist(ctx, pgApi, &user)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: time.Minute}, err
+	} else if !existing {
+		// Return if any database is missing
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
+
 	// update ownership and permissions for databases
 	if err := r.updateDatabaseOwnershipAndPrivileges(ctx, pgApi, &user); err != nil {
 		return ctrl.Result{RequeueAfter: time.Minute}, err
@@ -125,7 +135,7 @@ func (r *PgUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		controllerutil.AddFinalizer(&user, apiV1.DefaultFinalizerPgUser)
 		err = r.Update(ctx, &user)
 		if err != nil {
-			return ctrl.Result{RequeueAfter: time.Minute}, err
+			return ctrl.Result{RequeueAfter: time.Second}, err
 		}
 	}
 
@@ -187,7 +197,7 @@ func (r *PgUserReconciler) finalize(ctx context.Context, user *apiV1.PgUser, pgA
 	}
 
 	// Update Login Role Exists Condition
-	if err := setCondition(ctx, r, user, apiV1.PgUserExistsConditionType, false, "-", "-"); err != nil {
+	if err := setCondition(ctx, r.Status(), user, apiV1.PgUserExistsConditionType, false, "MissingUser", "-"); err != nil {
 		logger.Error(err, "Unable to update condition")
 		return err
 	}
@@ -316,6 +326,36 @@ func (r *PgUserReconciler) generateSecretData(pgApi PgRoleAPI, user *apiV1.PgUse
 		binaryData[key] = []byte(element)
 	}
 	return binaryData
+}
+
+func (r *PgUserReconciler) checkIfDatabasesExist(ctx context.Context, pgApi PgRoleAPI, user *apiV1.PgUser) (bool, error) {
+	databaseNames := make(map[string]bool)
+	for _, item := range user.Spec.Databases {
+		exists, err := pgApi.IsDatabaseExisting(item.Name)
+		if err != nil {
+			return false, err
+		}
+		databaseNames[item.Name] = exists
+	}
+	allDatabasesExist := true
+	reason := "DatabasesExist"
+	message := "All databases exist"
+	missingDBs := make([]string, 0)
+	for name, exist := range databaseNames {
+		if exist {
+			continue
+		}
+		missingDBs = append(missingDBs, name)
+		allDatabasesExist = allDatabasesExist && exist
+	}
+	if len(missingDBs) > 0 {
+		reason = "DatabasesMissing"
+		message = "The instance does not contain the databases: " + strings.Join(missingDBs, ",")
+	}
+	if err := setCondition(ctx, r.Status(), user, apiV1.PgUserDatabasesExistsConditionType, allDatabasesExist, reason, message); err != nil {
+		return false, err
+	}
+	return allDatabasesExist, nil
 }
 
 func (r *PgUserReconciler) updateDatabaseOwnershipAndPrivileges(ctx context.Context, pgApi PgRoleAPI, user *apiV1.PgUser) error {

--- a/controllers/pguser_controller_test.go
+++ b/controllers/pguser_controller_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	coreV1 "k8s.io/api/core/v1"
-	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -250,8 +250,16 @@ var _ = Describe("PgUserReconciler", func() {
 		var user apiV1.PgUser
 		err = k8sClient.Get(ctx, request.NamespacedName, &user)
 		Expect(err).To(BeNil())
-		Expect(user.Status.Conditions).To(HaveLen(1))
-		Expect(user.Status.Conditions[0].Status).To(Equal(metaV1.ConditionTrue))
+		Expect(user.Status.Conditions).To(HaveLen(3))
+		// and connection is true
+		connectionCondition := meta.FindStatusCondition(user.Status.Conditions, apiV1.PgConnectedConditionType)
+		Expect(connectionCondition.Status).To(Equal(v1.ConditionTrue))
+		// and user is true
+		userCondition := meta.FindStatusCondition(user.Status.Conditions, apiV1.PgUserExistsConditionType)
+		Expect(userCondition.Status).To(Equal(v1.ConditionTrue))
+		// and database is true
+		databaseCondition := meta.FindStatusCondition(user.Status.Conditions, apiV1.PgUserDatabasesExistsConditionType)
+		Expect(databaseCondition.Status).To(Equal(v1.ConditionTrue))
 
 		// and
 		user = apiV1.PgUser{}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"time"
 
-	apiV1 "github.com/brose-ebike/postgres-operator/api/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +67,7 @@ func setCondition(
 		return nil
 	}
 	condition := metaV1.Condition{
-		Type:               apiV1.PgConnectedConditionType,
+		Type:               conditionType,
 		Status:             statusString,
 		ObservedGeneration: obj.GetGeneration(),
 		LastTransitionTime: metaV1.Time{Time: time.Time{}},
@@ -76,6 +75,19 @@ func setCondition(
 		Message:            message,
 	}
 	meta.SetStatusCondition(&conditions, condition)
+	obj.SetConditions(conditions)
+	return r.Update(ctx, obj)
+}
+
+// removeCondition removes the condition with the given type from the given object
+func removeCondition(
+	ctx context.Context,
+	r client.StatusWriter,
+	obj ObjectWithConditions,
+	conditionType string,
+) error {
+	conditions := obj.GetConditions()
+	meta.RemoveStatusCondition(&conditions, conditionType)
 	obj.SetConditions(conditions)
 	return r.Update(ctx, obj)
 }


### PR DESCRIPTION
A resource in K8s can set conditions which represent the current state of the resource (e.g. Persitent Volume Claim storage acquired). For the PgDatabase resource a condition should be present, which represent the existence state of the database.
For the PgUser resource a condition should be present, which represent the existence state of the user.
Additionally the PgUser resource should contain a condition which represent the state of the referenced databases (e.g. all referenced databases exist, or any database is missing).