### PR TITLE
BRS-4215 Delete User only if exists

### DIFF
--- a/controllers/pgdatabase_controller_test.go
+++ b/controllers/pgdatabase_controller_test.go
@@ -255,25 +255,7 @@ var _ = Describe("PgInstanceReconciler", func() {
 	AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// Instances
-		instance := apiV1.PgInstance{}
-		opts := []client.DeleteAllOfOption{
-			client.InNamespace("default"),
-			client.GracePeriodSeconds(5),
-		}
-		err := k8sClient.DeleteAllOf(ctx, &instance, opts...)
-		Expect(err).To(BeNil())
-		//Databases
-		databases := apiV1.PgDatabaseList{}
-		err = k8sClient.List(ctx, &databases)
-		Expect(err).To(BeNil())
-		for _, db := range databases.Items {
-			db.Finalizers = []string{}
-			err = k8sClient.Update(ctx, &db)
-			Expect(err).To(BeNil())
-		}
-		database := apiV1.PgDatabase{}
-		err = k8sClient.DeleteAllOf(ctx, &database, opts...)
+		err := deleteAllCustomResources(ctx, k8sClient, "default")
 		Expect(err).To(BeNil())
 	})
 

--- a/controllers/pginstance_controller_test.go
+++ b/controllers/pginstance_controller_test.go
@@ -120,13 +120,7 @@ var _ = Describe("PgInstanceReconciler", func() {
 	AfterEach(func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// Instances
-		instance := apiV1.PgInstance{}
-		opts := []client.DeleteAllOfOption{
-			client.InNamespace("default"),
-			client.GracePeriodSeconds(5),
-		}
-		err := k8sClient.DeleteAllOf(ctx, &instance, opts...)
+		err := deleteAllCustomResources(ctx, k8sClient, "default")
 		Expect(err).To(BeNil())
 	})
 

--- a/controllers/pguser_controller.go
+++ b/controllers/pguser_controller.go
@@ -227,8 +227,7 @@ func (r *PgUserReconciler) finalize(ctx context.Context, user *apiV1.PgUser, pgA
 
 	// Remove finalizer
 	controllerutil.RemoveFinalizer(user, apiV1.DefaultFinalizerPgUser)
-	err = r.Update(ctx, user)
-	if err != nil {
+	if err := r.Update(ctx, user); err != nil {
 		return err
 	}
 

--- a/controllers/pguser_controller.go
+++ b/controllers/pguser_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -194,13 +195,13 @@ func (r *PgUserReconciler) finalize(ctx context.Context, user *apiV1.PgUser, pgA
 	// Delete only if user exists
 	exists, err := pgApi.IsRoleExisting(user.Name)
 	if err != nil {
-		logger.Error(err, "Unable to check users existence "+user.Name+" from "+user.GetInstanceIdString())
+		logger.Error(err, fmt.Sprintf("Unable to check user`s existence %s from %s", user.Name, user.GetInstanceIdString()))
 		return err
 	}
 
 	if exists {
 		if err := pgApi.DeleteRole(user.Name); err != nil {
-			logger.Error(err, "Unable to remove login role "+user.Name+" from "+user.GetInstanceIdString())
+			logger.Error(err, fmt.Sprintf("Unable to remove login role %s from %s", user.Name, user.GetInstanceIdString()))
 			return err
 		}
 	}
@@ -241,17 +242,17 @@ func (r *PgUserReconciler) createLoginRoleIfNotExists(ctx context.Context, pgApi
 
 	exists, err := pgApi.IsRoleExisting(roleName)
 	if err != nil {
-		logger.Error(err, "Unable to query login role "+roleName)
+		logger.Error(err, fmt.Sprintf("Unable to query login role %s", roleName))
 		return err
 	}
 
 	// create roles
 	if !exists {
 		if err := pgApi.CreateRole(roleName); err != nil {
-			logger.Error(err, "Unable to create login role "+roleName)
+			logger.Error(err, fmt.Sprintf("Unable to create login role %s", roleName))
 			return err
 		}
-		logger.Info("Created login role " + roleName)
+		logger.Info(fmt.Sprintf("Created login role %s", roleName))
 	}
 	return nil
 }
@@ -268,7 +269,7 @@ func (r *PgUserReconciler) createOrUpdateSecret(ctx context.Context, pgApi PgRol
 	}
 	err := r.Get(ctx, secretKey, &roleSecret)
 	if err != nil && !kErrors.IsNotFound(err) {
-		logger.Error(err, "Unable to fetch role secret for login role "+roleName)
+		logger.Error(err, fmt.Sprintf("Unable to fetch role secret for login role %s", roleName))
 		return "", err
 	} else if err != nil && kErrors.IsNotFound(err) { // Create Secret
 		password = security.GeneratePassword()
@@ -290,7 +291,7 @@ func (r *PgUserReconciler) createOrUpdateSecret(ctx context.Context, pgApi PgRol
 			Data: r.generateSecretData(pgApi, user, password),
 		}
 		if err := r.Create(ctx, &roleSecret); err != nil {
-			logger.Error(err, "Unable to create role secret for login role "+roleName)
+			logger.Error(err, fmt.Sprintf("Unable to create role secret for login role %s", roleName))
 			return "", err
 		}
 	} else { // Update Secret
@@ -310,7 +311,7 @@ func (r *PgUserReconciler) createOrUpdateSecret(ctx context.Context, pgApi PgRol
 		roleSecret.Data = r.generateSecretData(pgApi, user, password)
 		err = r.Update(ctx, &roleSecret)
 		if err != nil {
-			logger.Error(err, "Unable to update role secret for login role "+roleName)
+			logger.Error(err, fmt.Sprintf("Unable to update role secret for login role %s", roleName))
 			return "", err
 		}
 	}

--- a/controllers/pguser_controller_test.go
+++ b/controllers/pguser_controller_test.go
@@ -450,7 +450,7 @@ var _ = Describe("PgUserReconciler finalize", func() {
 		Expect(pgApiMock.(*pgRoleMock).callsDeleteRole).To(BeZero())
 	})
 
-	It("handles missing secret", func() {
+	It("handles user deletion with secret", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		// given
@@ -475,6 +475,9 @@ var _ = Describe("PgUserReconciler finalize", func() {
 		Expect(err).To(BeNil())
 
 		// and
+		pgApiMock.(*pgRoleMock).roles["existing"] = true
+
+		// and
 		secret := coreV1.Secret{
 			ObjectMeta: v1.ObjectMeta{
 				Namespace: "default",
@@ -492,5 +495,11 @@ var _ = Describe("PgUserReconciler finalize", func() {
 		Expect(err).To(BeNil())
 		Expect(pgApiMock.(*pgRoleMock).callsIsRoleExisting).To(Equal(1))
 		Expect(pgApiMock.(*pgRoleMock).callsDeleteRole).To(BeZero())
+
+		// and secret does not exist
+		secret = coreV1.Secret{}
+		exists, err := getResource(ctx, k8sClient, types.NamespacedName{Namespace: "default", Name: "credentials"}, &secret)
+		Expect(err).To(BeNil())
+		Expect(exists).To(BeFalse())
 	})
 })

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -93,12 +93,31 @@ func removeCondition(
 	return r.Update(ctx, obj)
 }
 
+// deleteAllCustomResources force deletes all custom resources (PgUser, PgDatabase and PgInstance)
+// without executing the finalizers.
+// THIS METHOD SHOULD ONLY BE USED FOR TESTING
 func deleteAllCustomResources(ctx context.Context, c client.Client, namespace string) error {
 	opts := []client.DeleteAllOfOption{
 		client.InNamespace(namespace),
 		client.GracePeriodSeconds(5),
 	}
 	// Delete all users
+	if err := deleteAllPgUsers(ctx, c, opts); err != nil {
+		return err
+	}
+	// Delete all databases
+	if err := deleteAllPgDatabases(ctx, c, opts); err != nil {
+		return err
+	}
+	// Delete all instances
+	if err := deleteAllPgInstances(ctx, c, opts); err != nil {
+		return err
+	}
+	return nil
+}
+
+// THIS METHOD SHOULD ONLY BE USED FOR TESTING
+func deleteAllPgUsers(ctx context.Context, c client.Client, opts []client.DeleteAllOfOption) error {
 	users := apiV1.PgUserList{}
 	if err := c.List(ctx, &users); err != nil {
 		return nil
@@ -114,8 +133,11 @@ func deleteAllCustomResources(ctx context.Context, c client.Client, namespace st
 	if err := c.DeleteAllOf(ctx, &user, opts...); err != nil {
 		return err
 	}
+	return nil
+}
 
-	// Delete all databases
+// THIS METHOD SHOULD ONLY BE USED FOR TESTING
+func deleteAllPgDatabases(ctx context.Context, c client.Client, opts []client.DeleteAllOfOption) error {
 	databases := apiV1.PgDatabaseList{}
 	if err := c.List(ctx, &databases); err != nil {
 		return nil
@@ -131,9 +153,13 @@ func deleteAllCustomResources(ctx context.Context, c client.Client, namespace st
 	if err := c.DeleteAllOf(ctx, &database, opts...); err != nil {
 		return err
 	}
-	// Delete all instances
+	return nil
+}
+
+// THIS METHOD SHOULD ONLY BE USED FOR TESTING
+func deleteAllPgInstances(ctx context.Context, c client.Client, opts []client.DeleteAllOfOption) error {
 	instances := apiV1.PgInstanceList{}
-	if err := c.List(ctx, &users); err != nil {
+	if err := c.List(ctx, &instances); err != nil {
 		return nil
 	}
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -122,10 +122,10 @@ func deleteAllPgUsers(ctx context.Context, c client.Client, opts []client.Delete
 	if err := c.List(ctx, &users); err != nil {
 		return nil
 	}
-
-	for _, user := range users.Items {
-		user.Finalizers = []string{}
-		if err := c.Update(ctx, &user); err != nil {
+	for i := range users.Items {
+		userPtr := &users.Items[i]
+		userPtr.Finalizers = []string{}
+		if err := c.Update(ctx, userPtr); err != nil {
 			return err
 		}
 	}
@@ -142,10 +142,10 @@ func deleteAllPgDatabases(ctx context.Context, c client.Client, opts []client.De
 	if err := c.List(ctx, &databases); err != nil {
 		return nil
 	}
-
-	for _, db := range databases.Items {
-		db.Finalizers = []string{}
-		if err := c.Update(ctx, &db); err != nil {
+	for i := range databases.Items {
+		dbPtr := &databases.Items[i]
+		dbPtr.Finalizers = []string{}
+		if err := c.Update(ctx, dbPtr); err != nil {
 			return err
 		}
 	}
@@ -162,10 +162,10 @@ func deleteAllPgInstances(ctx context.Context, c client.Client, opts []client.De
 	if err := c.List(ctx, &instances); err != nil {
 		return nil
 	}
-
-	for _, instance := range instances.Items {
-		instance.Finalizers = []string{}
-		if err := c.Update(ctx, &instance); err != nil {
+	for i := range instances.Items {
+		instancePtr := &instances.Items[i]
+		instancePtr.Finalizers = []string{}
+		if err := c.Update(ctx, instancePtr); err != nil {
 			return err
 		}
 	}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -122,6 +122,7 @@ func deleteAllPgUsers(ctx context.Context, c client.Client, opts []client.Delete
 	if err := c.List(ctx, &users); err != nil {
 		return nil
 	}
+	// Remove the finalizers from all resource objects to ensure no logic gets executed before deletion
 	for i := range users.Items {
 		userPtr := &users.Items[i]
 		userPtr.Finalizers = []string{}
@@ -142,6 +143,7 @@ func deleteAllPgDatabases(ctx context.Context, c client.Client, opts []client.De
 	if err := c.List(ctx, &databases); err != nil {
 		return nil
 	}
+	// Remove the finalizers from all resource objects to ensure no logic gets executed before deletion
 	for i := range databases.Items {
 		dbPtr := &databases.Items[i]
 		dbPtr.Finalizers = []string{}
@@ -162,6 +164,7 @@ func deleteAllPgInstances(ctx context.Context, c client.Client, opts []client.De
 	if err := c.List(ctx, &instances); err != nil {
 		return nil
 	}
+	// Remove the finalizers from all resource objects to ensure no logic gets executed before deletion
 	for i := range instances.Items {
 		instancePtr := &instances.Items[i]
 		instancePtr.Finalizers = []string{}


### PR DESCRIPTION
# Description

If the user was already deleted in the Postgres Instance, no error should be raised during finalization of the resource.
Therefore a check for the existence of the user in the instance needs to be added.

For test the custom resource deletion should be moved to a function which handles the deletion of all custom resources.

## References
Ticket: BRS-4215

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
