### PR TITLE
BRS-4215 Wrap all Errors as SqlExecutionError

### DIFF
--- a/pkg/pgapi/database.go
+++ b/pkg/pgapi/database.go
@@ -97,21 +97,21 @@ func (s *pgInstanceAPIImpl) UpdateDatabaseOwner(databaseName string, roleName st
 		return err
 	}
 	// Execute Query
-	const queryG = "grant %s to %s;"
-	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryG, roleName, s.connectionString.username))
+	const queryGrant = "grant %s to %s;"
+	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryGrant, roleName, s.connectionString.username))
 	if err != nil {
-		return WrapSqlExecutionError(err, queryG, databaseName, s.connectionString.username)
+		return WrapSqlExecutionError(err, queryGrant, databaseName, s.connectionString.username)
 	}
 	// Execute Query
-	const queryA = "alter database %s owner to %s;"
-	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryA, databaseName, roleName))
+	const queryAlterDBOwner = "alter database %s owner to %s;"
+	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryAlterDBOwner, databaseName, roleName))
 	if err != nil {
-		return WrapSqlExecutionError(err, queryA, databaseName, roleName)
+		return WrapSqlExecutionError(err, queryAlterDBOwner, databaseName, roleName)
 	}
 	// Execute Query
-	const queryR = "revoke %s from %s;"
-	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryR, roleName, s.connectionString.username))
-	return WrapSqlExecutionError(err, queryR, databaseName, s.connectionString.username)
+	const queryRevoke = "revoke %s from %s;"
+	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryRevoke, roleName, s.connectionString.username))
+	return WrapSqlExecutionError(err, queryRevoke, databaseName, s.connectionString.username)
 }
 
 func (s *pgInstanceAPIImpl) UpdateDatabasePrivileges(databaseName string, roleName string, privileges []string) error {
@@ -130,10 +130,10 @@ func (s *pgInstanceAPIImpl) UpdateDatabasePrivileges(databaseName string, roleNa
 	}
 	// TODO replace revoke all with specific revoke for the privileges which are not contained in the slice
 	// revoke all
-	const queryR = "revoke all on database %s from %s;"
-	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryR, databaseName, roleName))
+	const queryRevoke = "revoke all on database %s from %s;"
+	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryRevoke, databaseName, roleName))
 	if err != nil {
-		return WrapSqlExecutionError(err, queryR, databaseName, roleName)
+		return WrapSqlExecutionError(err, queryRevoke, databaseName, roleName)
 	}
 	// no privileges need to be granted
 	if len(privileges) == 0 {
@@ -141,9 +141,9 @@ func (s *pgInstanceAPIImpl) UpdateDatabasePrivileges(databaseName string, roleNa
 	}
 	joinedPrivileges := strings.Join(privileges, ", ")
 	// grant all privileges
-	queryG := "grant " + joinedPrivileges + " on database %s to %s;"
-	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryG, databaseName, roleName))
-	return WrapSqlExecutionError(err, queryG, databaseName, roleName)
+	queryGrant := "grant " + joinedPrivileges + " on database %s to %s;"
+	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryGrant, databaseName, roleName))
+	return WrapSqlExecutionError(err, queryGrant, databaseName, roleName)
 }
 
 func (s *pgInstanceAPIImpl) GetDatabaseOwner(databaseName string) (string, error) {

--- a/pkg/pgapi/database_test.go
+++ b/pkg/pgapi/database_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pgapi
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -111,5 +113,20 @@ var _ = Describe("PostgresAPI Database Handling", func() {
 		exists, err := pgApi.IsDatabaseExtensionPresent(databaseName, "uuid-ossp")
 		Expect(exists).To(BeTrue())
 		Expect(err).To(BeNil())
+	})
+
+	It("cannot create a database twice", func() {
+		// Create new database
+		err := pgApi.CreateDatabase("dummy_db_6")
+		Expect(err).To(BeNil())
+		// Check if database exists
+		exists, err := pgApi.IsDatabaseExisting("dummy_db_6")
+		Expect(err).To(BeNil())
+		Expect(exists).To(BeTrue())
+		// Create the database twice
+		err = pgApi.CreateDatabase("dummy_db_6")
+		Expect(err).ToNot(BeNil())
+		Expect(err.Error()).To(Equal("Unable to execute query 'create database %s;' with arguments 'dummy_db_6'\npq: database \"dummy_db_6\" already exists"))
+		Expect(errors.Unwrap(err).Error()).To(Equal("pq: database \"dummy_db_6\" already exists"))
 	})
 })

--- a/pkg/pgapi/errors.go
+++ b/pkg/pgapi/errors.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2023 Brose Fahrzeugteile SE & Co. KG, Bamberg.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgapi
+
+import "strings"
+
+type SqlExecutionError struct {
+	msg   string
+	query string
+	args  []string
+	err   error
+}
+
+func WrapSqlExecutionError(err error, query string, args ...string) error {
+	if err == nil {
+		return nil
+	}
+	return &SqlExecutionError{
+		msg:   "Unable to execute query '" + query + "' with arguments '" + strings.Join(args, "','") + "'\n" + err.Error(),
+		query: query,
+		args:  args,
+		err:   err,
+	}
+}
+
+func (e *SqlExecutionError) Error() string { return e.msg }
+func (e *SqlExecutionError) Unwrap() error { return e.err }

--- a/pkg/pgapi/errors_test.go
+++ b/pkg/pgapi/errors_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 Brose Fahrzeugteile SE & Co. KG, Bamberg.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgapi
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PostgresAPI SqlExecutionError", func() {
+
+	It("can wrap other errors", func() {
+		err := WrapSqlExecutionError(errors.New("test"), "-")
+		Expect(err).ToNot(BeNil())
+	})
+
+	It("can pass nil", func() {
+		err := WrapSqlExecutionError(nil, "-")
+		Expect(err).To(BeNil())
+	})
+})

--- a/pkg/pgapi/general.go
+++ b/pkg/pgapi/general.go
@@ -141,31 +141,3 @@ func (s *pgInstanceAPIImpl) runIn(database string, runner func(ctx context.Conte
 
 	return err
 }
-
-func (s *pgInstanceAPIImpl) runInDatabase(database string, runner func(ctx context.Context, conn *sql.Conn) error) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	connectionString := s.connectionString.copy()
-	connectionString.database = database
-	db, err := sql.Open("postgres", connectionString.toString())
-	if err != nil {
-		return err
-	}
-
-	// Connect to Database Server
-	con, err := db.Conn(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = runner(ctx, con)
-
-	if err := con.Close(); err != nil {
-		return err
-	}
-	if err := db.Close(); err != nil {
-		return err
-	}
-
-	return err
-}

--- a/pkg/pgapi/role.go
+++ b/pkg/pgapi/role.go
@@ -71,24 +71,24 @@ func (s *pgInstanceAPIImpl) DeleteRole(name string) error {
 
 	err = s.runAs(conn, name, func() error {
 		// reassign owned objects
-		const queryR = "reassign owned by %s to %s;"
-		_, err = conn.ExecContext(s.ctx, formatQueryObj(queryR, name, s.connectionString.username))
+		const queryReassign = "reassign owned by %s to %s;"
+		_, err = conn.ExecContext(s.ctx, formatQueryObj(queryReassign, name, s.connectionString.username))
 		if err != nil {
-			return WrapSqlExecutionError(err, queryR, name)
+			return WrapSqlExecutionError(err, queryReassign, name)
 		}
 		// drop all existing privileges
-		const queryD = "drop owned by %s;"
-		_, err = conn.ExecContext(s.ctx, formatQueryObj(queryD, name))
-		return WrapSqlExecutionError(err, queryD, name)
+		const queryDrop = "drop owned by %s;"
+		_, err = conn.ExecContext(s.ctx, formatQueryObj(queryDrop, name))
+		return WrapSqlExecutionError(err, queryDrop, name)
 	})
 	if err != nil {
 		return err
 	}
 
 	// Execute Drop User
-	const queryD = "drop user %s;"
-	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryD, name))
-	return WrapSqlExecutionError(err, queryD, name)
+	const queryDrop = "drop user %s;"
+	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryDrop, name))
+	return WrapSqlExecutionError(err, queryDrop, name)
 }
 
 func (s *pgInstanceAPIImpl) UpdateUserPassword(name string, password string) error {

--- a/pkg/pgapi/role.go
+++ b/pkg/pgapi/role.go
@@ -45,7 +45,7 @@ func (s *pgInstanceAPIImpl) IsRoleExisting(roleName string) (bool, error) {
 	const query = "select exists(select * from pg_catalog.pg_user where usename = $1);"
 	err = conn.QueryRowContext(s.ctx, query, roleName).Scan(&exists)
 	if err != nil {
-		return false, err
+		return false, WrapSqlExecutionError(err, query, roleName)
 	}
 	return exists, nil
 }
@@ -59,7 +59,7 @@ func (s *pgInstanceAPIImpl) CreateRole(name string) error {
 	// Execute Query
 	const query = "create user %s;"
 	_, err = conn.ExecContext(s.ctx, formatQueryObj(query, name))
-	return err
+	return WrapSqlExecutionError(err, query, name)
 }
 
 func (s *pgInstanceAPIImpl) DeleteRole(name string) error {
@@ -74,12 +74,12 @@ func (s *pgInstanceAPIImpl) DeleteRole(name string) error {
 		const queryR = "reassign owned by %s to %s;"
 		_, err = conn.ExecContext(s.ctx, formatQueryObj(queryR, name, s.connectionString.username))
 		if err != nil {
-			return err
+			return WrapSqlExecutionError(err, queryR, name)
 		}
 		// drop all existing privileges
 		const queryD = "drop owned by %s;"
 		_, err = conn.ExecContext(s.ctx, formatQueryObj(queryD, name))
-		return err
+		return WrapSqlExecutionError(err, queryD, name)
 	})
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (s *pgInstanceAPIImpl) DeleteRole(name string) error {
 	// Execute Drop User
 	const queryD = "drop user %s;"
 	_, err = conn.ExecContext(s.ctx, formatQueryObj(queryD, name))
-	return err
+	return WrapSqlExecutionError(err, queryD, name)
 }
 
 func (s *pgInstanceAPIImpl) UpdateUserPassword(name string, password string) error {
@@ -101,5 +101,5 @@ func (s *pgInstanceAPIImpl) UpdateUserPassword(name string, password string) err
 	password = strings.ReplaceAll(password, "'", "\\'")
 	query := "alter user %s with password '" + password + "' login;"
 	_, err = conn.ExecContext(s.ctx, formatQueryObj(query, name))
-	return err
+	return WrapSqlExecutionError(err, query, name)
 }

--- a/pkg/pgapi/schema.go
+++ b/pkg/pgapi/schema.go
@@ -88,9 +88,9 @@ func (s *pgInstanceAPIImpl) UpdateDefaultPrivileges(databaseName string, schemaN
 	// Run in Database
 	err := s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
 		joinedPrivileges := strings.Join(privileges, ", ")
-		queryB := "alter default privileges in schema  %s grant " + joinedPrivileges + " on " + typeName + " to  %s;"
-		_, err := conn.ExecContext(ctx, fmt.Sprintf(queryB, schemaName, roleName))
-		return WrapSqlExecutionError(err, queryB, schemaName, roleName)
+		query := "alter default privileges in schema  %s grant " + joinedPrivileges + " on " + typeName + " to  %s;"
+		_, err := conn.ExecContext(ctx, fmt.Sprintf(query, schemaName, roleName))
+		return WrapSqlExecutionError(err, query, schemaName, roleName)
 	})
 	return err
 }

--- a/pkg/pgapi/schema.go
+++ b/pkg/pgapi/schema.go
@@ -45,26 +45,27 @@ type PgSchemaAPI interface {
 
 func (s *pgInstanceAPIImpl) IsSchemaInDatabase(databaseName string, schemaName string) (bool, error) {
 	var exists bool
-	err := s.runInDatabase(databaseName, func(ctx context.Context, conn *sql.Conn) error {
+	err := s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
 		const query = "select exists(select * from pg_catalog.pg_namespace where nspname = $1);"
-		return conn.QueryRowContext(ctx, query, schemaName).Scan(&exists)
+		err := conn.QueryRowContext(ctx, query, schemaName).Scan(&exists)
+		return WrapSqlExecutionError(err, query, schemaName)
 	})
 	return exists, err
 }
 
 func (s *pgInstanceAPIImpl) CreateSchema(databaseName string, schemaName string) error {
-	return s.runInDatabase(databaseName, func(ctx context.Context, conn *sql.Conn) error {
+	return s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
 		const query = "create schema %s;"
 		_, err := conn.ExecContext(ctx, formatQueryObj(query, schemaName))
-		return err
+		return WrapSqlExecutionError(err, query, schemaName)
 	})
 }
 
 func (s *pgInstanceAPIImpl) DeleteSchema(databaseName string, schemaName string) error {
-	return s.runInDatabase(databaseName, func(ctx context.Context, conn *sql.Conn) error {
+	return s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
 		const query = "drop schema %s;"
 		_, err := conn.ExecContext(ctx, formatQueryObj(query, schemaName))
-		return err
+		return WrapSqlExecutionError(err, query, schemaName)
 	})
 }
 
@@ -85,20 +86,20 @@ func (s *pgInstanceAPIImpl) UpdateDefaultPrivileges(databaseName string, schemaN
 		}
 	}
 	// Run in Database
-	err := s.runInDatabase(databaseName, func(ctx context.Context, conn *sql.Conn) error {
+	err := s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
 		joinedPrivileges := strings.Join(privileges, ", ")
-		query := "alter default privileges in schema  %s grant " + joinedPrivileges + " on " + typeName + " to  %s;"
-		_, err := conn.ExecContext(ctx, fmt.Sprintf(query, schemaName, roleName))
-		return err
+		queryB := "alter default privileges in schema  %s grant " + joinedPrivileges + " on " + typeName + " to  %s;"
+		_, err := conn.ExecContext(ctx, fmt.Sprintf(queryB, schemaName, roleName))
+		return WrapSqlExecutionError(err, queryB, schemaName, roleName)
 	})
 	return err
 }
 
 func (s *pgInstanceAPIImpl) DeleteAllPrivilegesOnSchema(databaseName string, schemaName string, role string) error {
-	return s.runInDatabase(databaseName, func(ctx context.Context, conn *sql.Conn) error {
+	return s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
 		// This gets executed on the database `databaseName`
 		const query = "revoke all on schema %s from %s;"
 		_, err := conn.ExecContext(ctx, formatQueryObj(query, schemaName, role))
-		return err
+		return WrapSqlExecutionError(err, query, schemaName, role)
 	})
 }


### PR DESCRIPTION
# Description

### User Story
As a developer i want to have meaningful error messages because i need them to know what caused the error.


### Task Context
To make the errors during SQL execution more meaningful, each error should contain the query with all arguments addtional to the original error.

### Subtasks

* Create a SqlExecutionError type, which contains the original error, the query and all arguments
* Create a function which wraps an error in a SqlExecutionError
* The wrapper method should accept nil errors and return nil if the given error was nil
* Wrap all errors occuring during query execution in SqlExecutionError objects

## References
Ticket: BRS-4215

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
