### PR TITLE
BRS-4215 Fix Schema Default Privileges

### DIFF
--- a/api/v1/pgdatabase_types.go
+++ b/api/v1/pgdatabase_types.go
@@ -27,6 +27,9 @@ const DefaultFinalizerPgDatabase = "postgres.brose.bike/pgdatabase"
 const PgDatabaseExistsConditionType string = "pgdatabase.postgres.brose.bike/exists"
 const PgDatabaseExtensionsConditionType string = "pgdatabase.postgres.brose.bike/extensions"
 
+// +kubebuilder:validation:Enum=USAGE;CREATE
+type SchemaPrivilege string
+
 // +kubebuilder:validation:Enum=SELECT;INSERT;UPDATE;DELETE;TRUNCATE;REFERENCES;TRIGGER
 type TablePrivilege string
 
@@ -47,10 +50,12 @@ type PgDatabaseDeletion struct {
 }
 
 type PgDatabaseDefaultPrivileges struct {
+	// Name specifies the name of the schema for which the default privileges should be granted.
+	SchemaName string `json:"schemaName"`
 	// Roles specifies the name of the roles for which the privileges should be granted
 	Roles []string `json:"roles"`
-	// Name specifies the name of the schema for which the default privileges should be granted.
-	Name string `json:"name"`
+	// SchemaPrivileges specifies the privileges on this schema which should be granted to the roles
+	SchemaPrivileges []SchemaPrivilege `json:"schemaPrivileges,omitempty"`
 	// TablePrivileges specifies the name of the privileges on tables which should be granted to the roles
 	TablePrivileges []TablePrivilege `json:"tablePrivileges,omitempty"`
 	// SequencePrivileges specifies the name of the privileges on tables which should be granted to the roles
@@ -59,6 +64,14 @@ type PgDatabaseDefaultPrivileges struct {
 	FunctionPrivileges []FunctionPrivilege `json:"functionPrivileges,omitempty"`
 	// TypePrivileges specifies the name of the privileges on tables which should be granted to the roles
 	TypePrivileges []TypePrivilege `json:"typePrivileges,omitempty"`
+}
+
+func (dp *PgDatabaseDefaultPrivileges) PrivilegesStr() []string {
+	privileges := make([]string, len(dp.SchemaPrivileges))
+	for i := range dp.SchemaPrivileges {
+		privileges[i] = string(dp.SchemaPrivileges[i])
+	}
+	return privileges
 }
 
 func (dp *PgDatabaseDefaultPrivileges) TablePrivilegesStr() []string {
@@ -109,9 +122,9 @@ type PgDatabaseSpec struct {
 	// DeletionBehavior specifies what should happen when the manifest gets deleted
 	DeletionBehavior PgDatabaseDeletion `json:"deletion"`
 	// Extensions which should exist in this database
-	Extensions []string `json:"extensions"`
-	// DefaultPrivileges defines the default privileges for this database
-	DefaultPrivileges []PgDatabaseDefaultPrivileges `json:"defaultPrivileges"`
+	Extensions []string `json:"extensions,omitempty"`
+	// DefaultPrivileges defines the default privileges for schemas in this database
+	DefaultPrivileges []PgDatabaseDefaultPrivileges `json:"defaultPrivileges,omitempty"`
 	// PublicPrivileges revokes and Public stuff in postgres
 	PublicPrivileges PgDatabasePublicPrivileges `json:"publicPrivileges"`
 	// PublicSchema dropped

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -62,6 +62,11 @@ func (in *PgDatabaseDefaultPrivileges) DeepCopyInto(out *PgDatabaseDefaultPrivil
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SchemaPrivileges != nil {
+		in, out := &in.SchemaPrivileges, &out.SchemaPrivileges
+		*out = make([]SchemaPrivilege, len(*in))
+		copy(*out, *in)
+	}
 	if in.TablePrivileges != nil {
 		in, out := &in.TablePrivileges, &out.TablePrivileges
 		*out = make([]TablePrivilege, len(*in))

--- a/config/crd/bases/postgres.brose.bike_pgdatabases.yaml
+++ b/config/crd/bases/postgres.brose.bike_pgdatabases.yaml
@@ -37,7 +37,7 @@ spec:
             properties:
               defaultPrivileges:
                 description: DefaultPrivileges defines the default privileges for
-                  this database
+                  schemas in this database
                 items:
                   properties:
                     functionPrivileges:
@@ -48,14 +48,23 @@ spec:
                         - EXECUTE
                         type: string
                       type: array
-                    name:
-                      description: Name specifies the name of the schema for which
-                        the default privileges should be granted.
-                      type: string
                     roles:
                       description: Roles specifies the name of the roles for which
                         the privileges should be granted
                       items:
+                        type: string
+                      type: array
+                    schemaName:
+                      description: Name specifies the name of the schema for which
+                        the default privileges should be granted.
+                      type: string
+                    schemaPrivileges:
+                      description: SchemaPrivileges specifies the privileges on this
+                        schema which should be granted to the roles
+                      items:
+                        enum:
+                        - USAGE
+                        - CREATE
                         type: string
                       type: array
                     sequencePrivileges:
@@ -91,8 +100,8 @@ spec:
                         type: string
                       type: array
                   required:
-                  - name
                   - roles
+                  - schemaName
                   type: object
                 type: array
               deletion:
@@ -148,9 +157,7 @@ spec:
                 - drop
                 type: object
             required:
-            - defaultPrivileges
             - deletion
-            - extensions
             - instance
             - publicPrivileges
             - publicSchema

--- a/controllers/pgdatabase_controller.go
+++ b/controllers/pgdatabase_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -228,7 +229,7 @@ func (r *PgDatabaseReconciler) createDatabaseIfNotExists(ctx context.Context, pg
 
 	exists, err := pgApi.IsDatabaseExisting(databaseName)
 	if err != nil {
-		logger.Error(err, "Unable to query database"+databaseName)
+		logger.Error(err, "Unable to query database "+databaseName)
 		return err
 	}
 
@@ -265,30 +266,51 @@ func (r *PgDatabaseReconciler) handleExtensions(ctx context.Context, pgApi PgDat
 
 func (r *PgDatabaseReconciler) handleDefaultPrivileges(ctx context.Context, pgApi PgDatabaseAPI, database *apiV1.PgDatabase) error {
 	for _, schema := range database.Spec.DefaultPrivileges {
-		exists, err := pgApi.IsSchemaInDatabase(database.Name, schema.Name)
+		exists, err := pgApi.IsSchemaInDatabase(database.Name, schema.SchemaName)
 		if err != nil {
 			return err
 		}
 		if !exists {
-			if err := pgApi.CreateSchema(database.Name, schema.Name); err != nil {
+			return errors.New("Schema " + schema.SchemaName + " does not exist in database " + database.Name)
+		}
+		// Check schema permissions
+		usable, err := pgApi.IsSchemaUsable(database.Name, schema.SchemaName)
+		if err != nil {
+			return err
+		}
+		if !usable {
+			if err := pgApi.MakeSchemaUseable(database.Name, schema.SchemaName); err != nil {
 				return err
 			}
 		}
 		for _, role := range schema.Roles {
+			// Update schema privileges
+			if err := pgApi.UpdateSchemaPrivileges(database.Name, schema.SchemaName, role, schema.PrivilegesStr()); err != nil {
+				return err
+			}
 			// Update table privileges
-			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.Name, role, "TABLES", schema.TablePrivilegesStr()); err != nil {
+			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.SchemaName, role, "TABLES", schema.TablePrivilegesStr()); err != nil {
+				return err
+			}
+			if err := pgApi.UpdatePrivilegesOnAllObjects(database.Name, schema.SchemaName, role, "TABLES", schema.TablePrivilegesStr()); err != nil {
 				return err
 			}
 			// Update sequence privileges
-			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.Name, role, "SEQUENCES", schema.SequencePrivilegesStr()); err != nil {
+			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.SchemaName, role, "SEQUENCES", schema.SequencePrivilegesStr()); err != nil {
+				return err
+			}
+			if err := pgApi.UpdatePrivilegesOnAllObjects(database.Name, schema.SchemaName, role, "SEQUENCES", schema.SequencePrivilegesStr()); err != nil {
 				return err
 			}
 			// Update function privileges
-			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.Name, role, "FUNCTIONS", schema.FunctionPrivilegesStr()); err != nil {
+			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.SchemaName, role, "FUNCTIONS", schema.FunctionPrivilegesStr()); err != nil {
+				return err
+			}
+			if err := pgApi.UpdatePrivilegesOnAllObjects(database.Name, schema.SchemaName, role, "FUNCTIONS", schema.FunctionPrivilegesStr()); err != nil {
 				return err
 			}
 			// Update type privileges
-			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.Name, role, "TYPES", schema.TypePrivilegesStr()); err != nil {
+			if err := pgApi.UpdateDefaultPrivileges(database.Name, schema.SchemaName, role, "TYPES", schema.TypePrivilegesStr()); err != nil {
 				return err
 			}
 		}

--- a/controllers/pgdatabase_controller_test.go
+++ b/controllers/pgdatabase_controller_test.go
@@ -38,21 +38,26 @@ type dummyDB struct {
 }
 
 type pgDatabaseMock struct {
-	databases                        map[string]dummyDB
-	callsIsDatabaseExisting          int
-	callsCreateDatabase              int
-	callsDeleteDatabase              int
-	callsGetDatabaseOwner            int
-	callsUpdateDatabaseOwner         int
-	callsResetDatabaseOwner          int
-	callsUpdateDatabasePrivileges    int
-	callsIsSchemaInDatabase          int
-	callsCreateSchema                int
-	callsDeleteSchema                int
-	callsUpdateDefaultPrivileges     int
-	callsDeleteAllPrivilegesOnSchema int
-	callsIsDatabaseExtensionPresent  int
-	callsCreateDatabaseExtension     int
+	databases                         map[string]dummyDB
+	callsIsDatabaseExisting           int
+	callsCreateDatabase               int
+	callsDeleteDatabase               int
+	callsGetDatabaseOwner             int
+	callsUpdateDatabaseOwner          int
+	callsResetDatabaseOwner           int
+	callsUpdateDatabasePrivileges     int
+	callsIsSchemaInDatabase           int
+	callsCreateSchema                 int
+	callsDeleteSchema                 int
+	callsUpdateDefaultPrivileges      int
+	callsDeleteAllPrivilegesOnSchema  int
+	callsIsDatabaseExtensionPresent   int
+	callsCreateDatabaseExtension      int
+	callsUpdatePrivilegesOnAllObjects int
+	callsIsSchemaUsable               int
+	callsMakeSchemaUseable            int
+	callsUpdateSchemaPrivileges       int
+	callsGetSchemaOwner               int
 }
 
 func (m *pgDatabaseMock) IsDatabaseExisting(databaseName string) (bool, error) {
@@ -169,6 +174,31 @@ func (m *pgDatabaseMock) IsDatabaseExtensionPresent(databaseName string, extensi
 func (m *pgDatabaseMock) CreateDatabaseExtension(databaseName string, extension string) error {
 	m.callsCreateDatabaseExtension += 1
 	return nil
+}
+
+func (m *pgDatabaseMock) UpdatePrivilegesOnAllObjects(databaseName string, schemaName string, roleName string, typeName string, privileges []string) error {
+	m.callsUpdatePrivilegesOnAllObjects += 1
+	return nil
+}
+
+func (m *pgDatabaseMock) IsSchemaUsable(databaseName string, schemaName string) (bool, error) {
+	m.callsIsSchemaUsable += 1
+	return true, nil
+}
+
+func (m *pgDatabaseMock) MakeSchemaUseable(databaseName string, schemaName string) error {
+	m.callsMakeSchemaUseable += 1
+	return nil
+}
+
+func (m *pgDatabaseMock) UpdateSchemaPrivileges(databaseName string, schemaName string, roleName string, privileges []string) error {
+	m.callsUpdateSchemaPrivileges += 1
+	return nil
+}
+
+func (m *pgDatabaseMock) GetSchemaOwner(databaseName string, schemaName string) (string, error) {
+	m.callsGetSchemaOwner += 1
+	return "", nil
 }
 
 var _ = Describe("PgInstanceReconciler", func() {

--- a/pkg/pgapi/general.go
+++ b/pkg/pgapi/general.go
@@ -141,3 +141,56 @@ func (s *pgInstanceAPIImpl) runIn(database string, runner func(ctx context.Conte
 
 	return err
 }
+
+func (s *pgInstanceAPIImpl) runInAs(database string, role string, runner func(ctx context.Context, conn *sql.Conn) error) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Use new connection string
+	conStr := s.connectionString.copy()
+	conStr.database = database
+
+	// Start SQL Database
+	db, err := sql.Open("postgres", conStr.toString())
+	if err != nil {
+		return err
+	}
+
+	// Connect to Database Server
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+
+	myRole := s.connectionString.username
+	isMember, err := s.isMember(conn, myRole, role)
+	if err != nil {
+		return err
+	}
+	// Grant role to myRole
+	if !isMember {
+		const queryG = "grant %s to %s;"
+		_, err := conn.ExecContext(s.ctx, formatQueryObj(queryG, role, myRole))
+		if err != nil {
+			return err
+		}
+	}
+	// Execute runner
+	err = runner(ctx, conn)
+
+	// Revoke role to myRole
+	if !isMember {
+		const queryR = "revoke %s from %s;"
+		_, err := conn.ExecContext(s.ctx, formatQueryObj(queryR, role, myRole))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Close connection
+	if err := conn.Close(); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/pgapi/schema.go
+++ b/pkg/pgapi/schema.go
@@ -102,12 +102,10 @@ func (s *pgInstanceAPIImpl) UpdateSchemaPrivileges(databaseName string, schemaNa
 	if len(privileges) == 0 {
 		return nil
 	}
-	// Get Database Owner
 	dbOwner, err := s.GetDatabaseOwner(databaseName)
 	if err != nil {
 		return err
 	}
-	// Validate Privileges Parameter
 	if err := validatePrivileges(privileges); err != nil {
 		return err
 	}
@@ -125,15 +123,12 @@ func (s *pgInstanceAPIImpl) UpdatePrivilegesOnAllObjects(databaseName string, sc
 	if len(privileges) == 0 {
 		return nil
 	}
-	// Validate typeName Parameter
 	if err := validateTypeName(typeName); err != nil {
 		return err
 	}
-	// Validate Privileges Parameter
 	if err := validatePrivileges(privileges); err != nil {
 		return err
 	}
-	// Get Database Owner
 	dbOwner, err := s.GetDatabaseOwner(databaseName)
 	if err != nil {
 		return err

--- a/pkg/pgapi/schema.go
+++ b/pkg/pgapi/schema.go
@@ -26,6 +26,25 @@ import (
 	_ "github.com/lib/pq"
 )
 
+var pgTypes = []string{"TABLES", "SEQUENCES", "FUNCTIONS", "ROUTINES", "TYPES", "SCHEMAS"}
+var pgPrivileges = []string{"SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "USAGE", "CONNECT", "CREATE", "ALL"}
+
+func validateTypeName(typeName string) error {
+	if !hasElementString(pgTypes, typeName) {
+		return brose_errors.NewIllegalArgumentError("typeName", typeName, nil)
+	}
+	return nil
+}
+
+func validatePrivileges(privileges []string) error {
+	for _, privilege := range privileges {
+		if !hasElementString(pgPrivileges, privilege) {
+			return brose_errors.NewIllegalArgumentError("privileges", privilege, nil)
+		}
+	}
+	return nil
+}
+
 // PgSchemaAPI provides functionality to check and manipulate
 // schemas and privileges on schemas
 type PgSchemaAPI interface {
@@ -36,11 +55,21 @@ type PgSchemaAPI interface {
 	CreateSchema(databaseName string, schemaName string) error
 	// DeleteSchema drops the given schema from the given database
 	DeleteSchema(databaseName string, schemaName string) error
+	// UpdateSchemaPrivileges updates the privileges for the given schema
+	UpdateSchemaPrivileges(databaseName string, schemaName string, roleName string, privileges []string) error
+	// UpdatePrivilegesOnAllObjects updates the privileges according to the given parameters
+	UpdatePrivilegesOnAllObjects(databaseName string, schemaName string, roleName string, typeName string, privileges []string) error
 	// UpdateDefaultPrivileges updates the default privileges in the given schema
 	// for the given role on the given type to the given privileges
 	UpdateDefaultPrivileges(databaseName string, schemaName string, roleName string, typeName string, privileges []string) error
 	// DeleteAllPrivilegesOnSchema removes all privileges on the given schema for the given role
 	DeleteAllPrivilegesOnSchema(databaseName string, schemaName string, role string) error
+	// IsSchemaUsable checks if the current user has the use privilege on the given schema
+	IsSchemaUsable(databaseName string, schemaName string) (bool, error)
+	// MakeSchemaUseable grants the use privilege on the given schema to the current user
+	MakeSchemaUseable(databaseName string, schemaName string) error
+	// GetSchemaOwner returns the owner of the database with the given name on the connected instance
+	GetSchemaOwner(databaseName string, schemaName string) (string, error)
 }
 
 func (s *pgInstanceAPIImpl) IsSchemaInDatabase(databaseName string, schemaName string) (bool, error) {
@@ -69,21 +98,66 @@ func (s *pgInstanceAPIImpl) DeleteSchema(databaseName string, schemaName string)
 	})
 }
 
+func (s *pgInstanceAPIImpl) UpdateSchemaPrivileges(databaseName string, schemaName string, roleName string, privileges []string) error {
+	if len(privileges) == 0 {
+		return nil
+	}
+	// Get Database Owner
+	dbOwner, err := s.GetDatabaseOwner(databaseName)
+	if err != nil {
+		return err
+	}
+	// Validate Privileges Parameter
+	if err := validatePrivileges(privileges); err != nil {
+		return err
+	}
+	// Execute Grants
+	return s.runInAs(databaseName, dbOwner, func(ctx context.Context, conn *sql.Conn) error {
+		// This gets executed on the database `databaseName`
+		joinedPrivileges := strings.Join(privileges, ", ")
+		var queryB = "GRANT " + joinedPrivileges + " ON SCHEMA %s TO %s;"
+		_, err := conn.ExecContext(ctx, formatQueryObj(queryB, schemaName, roleName))
+		return WrapSqlExecutionError(err, queryB, schemaName, roleName)
+	})
+}
+
+func (s *pgInstanceAPIImpl) UpdatePrivilegesOnAllObjects(databaseName string, schemaName string, roleName string, typeName string, privileges []string) error {
+	if len(privileges) == 0 {
+		return nil
+	}
+	// Validate typeName Parameter
+	if err := validateTypeName(typeName); err != nil {
+		return err
+	}
+	// Validate Privileges Parameter
+	if err := validatePrivileges(privileges); err != nil {
+		return err
+	}
+	// Get Database Owner
+	dbOwner, err := s.GetDatabaseOwner(databaseName)
+	if err != nil {
+		return err
+	}
+	// Execute Grants
+	return s.runInAs(databaseName, dbOwner, func(ctx context.Context, conn *sql.Conn) error {
+		joinedPrivileges := strings.Join(privileges, ", ")
+		query := "GRANT " + joinedPrivileges + " ON ALL " + typeName + " IN SCHEMA %s TO  %s;"
+		_, err := conn.ExecContext(ctx, formatQueryObj(query, schemaName, roleName))
+		return WrapSqlExecutionError(err, query, schemaName, roleName)
+	})
+}
+
 func (s *pgInstanceAPIImpl) UpdateDefaultPrivileges(databaseName string, schemaName string, roleName string, typeName string, privileges []string) error {
 	if len(privileges) == 0 {
 		return nil
 	}
 	// Validate typeName Parameter
-	allowedTypes := []string{"TABLES", "SEQUENCES", "FUNCTIONS", "ROUTINES", "TYPES", "SCHEMAS"}
-	if !hasElementString(allowedTypes, typeName) {
-		return brose_errors.NewIllegalArgumentError("typeName", typeName, nil)
+	if err := validateTypeName(typeName); err != nil {
+		return err
 	}
 	// Validate Privileges Parameter
-	allowedPrivileges := []string{"SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "USAGE", "CONNECT", "ALL"}
-	for _, privilege := range privileges {
-		if !hasElementString(allowedPrivileges, privilege) {
-			return brose_errors.NewIllegalArgumentError("privileges", privilege, nil)
-		}
+	if err := validatePrivileges(privileges); err != nil {
+		return err
 	}
 	// Run in Database
 	err := s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
@@ -102,4 +176,45 @@ func (s *pgInstanceAPIImpl) DeleteAllPrivilegesOnSchema(databaseName string, sch
 		_, err := conn.ExecContext(ctx, formatQueryObj(query, schemaName, role))
 		return WrapSqlExecutionError(err, query, schemaName, role)
 	})
+}
+
+func (s *pgInstanceAPIImpl) IsSchemaUsable(databaseName string, schemaName string) (bool, error) {
+	var useable bool
+	err := s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
+		const query = "SELECT pg_catalog.has_schema_privilege(current_user, $1, 'USAGE');"
+		err := conn.QueryRowContext(ctx, query, schemaName).Scan(&useable)
+		return WrapSqlExecutionError(err, query, schemaName)
+	})
+	return useable, err
+}
+
+func (s *pgInstanceAPIImpl) MakeSchemaUseable(databaseName string, schemaName string) error {
+	// Get Database Owner
+	schemaOwner, err := s.GetSchemaOwner(databaseName, schemaName)
+	if err != nil {
+		return err
+	}
+
+	// Execute Grants
+	return s.runInAs(databaseName, schemaOwner, func(ctx context.Context, conn *sql.Conn) error {
+		// This gets executed on the database `databaseName`
+		const queryA = "GRANT CONNECT ON DATABASE %s TO %s;"
+		if _, err := conn.ExecContext(ctx, formatQueryObj(queryA, databaseName, s.connectionString.username)); err != nil {
+			return WrapSqlExecutionError(err, queryA, schemaName, s.connectionString.username)
+		}
+		// This gets executed on the database `databaseName`
+		const queryB = "GRANT USAGE ON SCHEMA %s TO %s;"
+		_, err := conn.ExecContext(ctx, formatQueryObj(queryB, schemaName, s.connectionString.username))
+		return WrapSqlExecutionError(err, queryB, schemaName, s.connectionString.username)
+	})
+}
+
+func (s *pgInstanceAPIImpl) GetSchemaOwner(databaseName string, schemaName string) (string, error) {
+	var schemaOwner string
+	err := s.runIn(databaseName, func(ctx context.Context, conn *sql.Conn) error {
+		const query = "select r.rolname as schema_owner from pg_namespace ns join pg_roles r on ns.nspowner = r.oid where nspname=$1;"
+		err := conn.QueryRowContext(s.ctx, query, schemaName).Scan(&schemaOwner)
+		return WrapSqlExecutionError(err, query, schemaName)
+	})
+	return schemaOwner, err
 }

--- a/pkg/pgapi/schema_test.go
+++ b/pkg/pgapi/schema_test.go
@@ -101,4 +101,22 @@ var _ = Describe("PostgresAPI Schema Handling", func() {
 		err = pgApi.DeleteAllPrivilegesOnSchema(databaseName, schemaName, roleName)
 		Expect(err).To(BeNil())
 	})
+
+	It("can update privileges", func() {
+		roleName := "dummy_role_9"
+		databaseName := "dummy_db_15"
+		schemaName := "service"
+		// Create new role
+		err := pgApi.CreateRole(roleName)
+		Expect(err).To(BeNil())
+		// Create new database
+		err = pgApi.CreateDatabase(databaseName)
+		Expect(err).To(BeNil())
+		// Create Schema
+		err = pgApi.CreateSchema(databaseName, schemaName)
+		Expect(err).To(BeNil())
+		// Update Schema Privileges
+		err = pgApi.UpdatePrivilegesOnAllObjects(databaseName, schemaName, roleName, "TABLES", []string{"SELECT"})
+		Expect(err).To(BeNil())
+	})
 })


### PR DESCRIPTION
# Description

Before applying the default privileges we need to ensure the database is useable by the admin user.
We also need to specify the schema privileges for the roles which get default privileges.
If only a select privilege on all tables is granted, the role is not automatically allowed to use the schema.
Therefore the schema permissions need to be specified as well.

## References
Ticket: BRS-4215

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
